### PR TITLE
Feature/provide-super-classes

### DIFF
--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -507,6 +507,18 @@ teamingAI:InclusiveGatewayMapping
         rr:objectMap [ rr:constant bbo:InclusiveGateway ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Gateway ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -715,6 +715,14 @@ teamingAI:MessageEventDefinitionMapping
         rr:objectMap [ rr:constant bbo:MessageEventDefinition ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:EventDefinition ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:RootElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -1067,6 +1067,22 @@ teamingAI:ServiceTaskMapping
         rr:objectMap [ rr:constant bbo:ServiceTask ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Task ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Activity ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -347,6 +347,22 @@ teamingAI:EndEventMapping
         rr:objectMap [ rr:constant bbo:EndEvent ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:ThrowEvent ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Event ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -455,6 +455,18 @@ teamingAI:ExlusiveGatewayMapping
         rr:objectMap [ rr:constant bbo:ExclusiveGateway ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Gateway ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -1147,6 +1147,22 @@ teamingAI:StartEventMapping
         rr:objectMap [ rr:constant bbo:StartEvent ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:CatchEvent ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Event ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -867,6 +867,18 @@ teamingAI:ProcessMapping
         rr:objectMap [ rr:constant bbo:Process ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElementsContainer ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:CallableElement ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:RootElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -671,6 +671,22 @@ teamingAI:ManualTaskMapping
         rr:objectMap [ rr:constant bbo:ManualTask ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Task ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Activity ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -899,6 +899,22 @@ teamingAI:ReceiveTaskMapping
         rr:objectMap [ rr:constant bbo:ReceiveTask ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Task ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Activity ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -783,6 +783,18 @@ teamingAI:ParallelGatewayMapping
         rr:objectMap [ rr:constant bbo:ParallelGateway ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Gateway ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -71,6 +71,22 @@ teamingAI:BoundaryEventMapping
         rr:objectMap [ rr:constant bbo:BoundaryEvent ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:CatchEvent ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Event ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -1063,6 +1063,10 @@ teamingAI:SequenceFlowMapping
         rr:objectMap [ rr:constant bbo:SequenceFlow ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -1171,6 +1171,18 @@ teamingAI:TaskMapping
         rr:objectMap [ rr:constant bbo:Task ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Activity ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -943,6 +943,22 @@ teamingAI:ScriptTaskMapping
         rr:objectMap [ rr:constant bbo:ScriptTask ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Task ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Activity ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -427,6 +427,10 @@ teamingAI:ErrorMapping
         rr:objectMap [ rr:constant bbo:Error ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:RootElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -987,6 +987,22 @@ teamingAI:SendTaskMapping
         rr:objectMap [ rr:constant bbo:SendTask ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Task ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Activity ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -1195,6 +1195,22 @@ teamingAI:SubProcessMapping
         rr:objectMap [ rr:constant bbo:SubProcess ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Activity ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElementsContainer ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -395,6 +395,14 @@ teamingAI:ErrorEventDefinitionMapping
         rr:objectMap [ rr:constant bbo:ErrorEventDefinition ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:EventDefinition ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:RootElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -17,8 +17,7 @@ export const mapping = (uploadResourceUri) => `
 <#UuidFunctionMapping>
     fnml:functionValue [
         rr:subjectMap <#UuidFunctionMapping>;
-
-    rr:predicateObjectMap [
+        rr:predicateObjectMap [
             rr:predicate fno:executes ;
             rr:objectMap [ rr:constant idlab-fn:random ]
         ]
@@ -110,6 +109,22 @@ teamingAI:BusinessRuleTaskMapping
     rr:predicateObjectMap [
         rr:predicate rdf:type;
         rr:objectMap [ rr:constant bbo:BusinessRuleTask ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Task ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Activity ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
     ],
     [
         rr:predicate muCore:uuid;

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -1239,6 +1239,22 @@ teamingAI:UserTaskMapping
         rr:objectMap [ rr:constant bbo:UserTask ]
     ],
     [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Task ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Activity ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
+    ],
+    [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
     ],

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -543,7 +543,7 @@ teamingAI:InclusiveGatewayMapping
         rr:objectMap [ rr:template "{./*[name()='bpmn:incoming']}" ]
     ].
 
-teamingAI:IntermediateThrowMapping
+teamingAI:IntermediateThrowEventMapping
     a rr:TriplesMap;
 
     rml:logicalSource [
@@ -557,6 +557,22 @@ teamingAI:IntermediateThrowMapping
     rr:predicateObjectMap [
         rr:predicate rdf:type;
         rr:objectMap [ rr:constant bbo:IntermediateThrowEvent ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:ThrowEvent ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:Event ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowNode ]
+    ],
+    [
+        rr:predicate rdf:type;
+        rr:objectMap [ rr:constant bbo:FlowElement ]
     ],
     [
         rr:predicate muCore:uuid;


### PR DESCRIPTION
Based on the ontology (https://www.irit.fr/recherches/MELODI/ontologies/BBO/webvowl/index.html#opts=doc=0;filter_datatypes=true;filter_objectProperties=true;filter_sco=true;filter_setOperator=true;), the mapping now creates resources with all types that it conforms to (thus also its superclasses