### PR TITLE
Feature/bpmn-element-classification

### DIFF
--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -46,7 +46,10 @@ teamingAI:AssociationMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:00cbc3c9-b2a8-4474-bbe9-c3a977f3feaf ]
+        rr:objectMap [
+            rr:constant ns1:00cbc3c9-b2a8-4474-bbe9-c3a977f3feaf;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -98,7 +101,10 @@ teamingAI:BoundaryEventMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:9a72a481-d111-405b-903b-18242e121502 ]
+        rr:objectMap [
+            rr:constant ns1:9a72a481-d111-405b-903b-18242e121502;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:attachedToRef;
@@ -162,7 +168,10 @@ teamingAI:BusinessRuleTaskMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:546044f1-455c-4949-8d45-df024bc76b49 ]
+        rr:objectMap [
+            rr:constant ns1:546044f1-455c-4949-8d45-df024bc76b49;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -194,7 +203,10 @@ teamingAI:CollaborationMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:ff8338d3-c491-413c-aae3-2a57dc3f75f5 ]
+        rr:objectMap [
+            rr:constant ns1:ff8338d3-c491-413c-aae3-2a57dc3f75f5;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -222,7 +234,10 @@ teamingAI:DataInputAssociationMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:7a53a259-0e26-4688-8137-be50458264ec ]
+        rr:objectMap [
+            rr:constant ns1:7a53a259-0e26-4688-8137-be50458264ec;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -262,7 +277,10 @@ teamingAI:DataObjectMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:3e0a146b-b483-40e7-a901-3144d5be2ee2 ]
+        rr:objectMap [
+            rr:constant ns1:3e0a146b-b483-40e7-a901-3144d5be2ee2;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -290,7 +308,10 @@ teamingAI:DataObjectReferenceMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:ad8ee890-12a8-4a8a-bb23-10b3b2403df0 ]
+        rr:objectMap [
+            rr:constant ns1:ad8ee890-12a8-4a8a-bb23-10b3b2403df0;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -326,7 +347,10 @@ teamingAI:DataOutputAssociationMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:63da1337-6cd7-441c-a5c1-940f2fbd0f34 ]
+        rr:objectMap [
+            rr:constant ns1:63da1337-6cd7-441c-a5c1-940f2fbd0f34;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -362,7 +386,10 @@ teamingAI:DataStoreReferenceMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:b5de5008-7aeb-41c5-a2f2-26f1d4ca6d49 ]
+        rr:objectMap [
+            rr:constant ns1:b5de5008-7aeb-41c5-a2f2-26f1d4ca6d49;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -410,7 +437,10 @@ teamingAI:EndEventMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:55e98451-1f29-420c-87e3-3e01a7d5abc5 ]
+        rr:objectMap [
+            rr:constant ns1:55e98451-1f29-420c-87e3-3e01a7d5abc5;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -454,7 +484,10 @@ teamingAI:ErrorEventDefinitionMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:107c7feb-64ff-409f-a5ce-1e85324274fc ]
+        rr:objectMap [
+            rr:constant ns1:107c7feb-64ff-409f-a5ce-1e85324274fc;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -486,7 +519,10 @@ teamingAI:ErrorMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:cc636682-385a-4e63-8043-740d34e06254 ]
+        rr:objectMap [
+            rr:constant ns1:cc636682-385a-4e63-8043-740d34e06254;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -530,7 +566,10 @@ teamingAI:ExlusiveGatewayMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:0bf0aea4-798d-4d7a-bd44-34f09f763eb3 ]
+        rr:objectMap [
+            rr:constant ns1:0bf0aea4-798d-4d7a-bd44-34f09f763eb3;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -586,7 +625,10 @@ teamingAI:InclusiveGatewayMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:76d6c227-ca62-4b47-8829-ebf1b60c3671 ]
+        rr:objectMap [
+            rr:constant ns1:76d6c227-ca62-4b47-8829-ebf1b60c3671;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -646,7 +688,10 @@ teamingAI:IntermediateThrowEventMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:6f1559a6-e0af-41bf-b14e-ff2597a3d8dc ]
+        rr:objectMap [
+            rr:constant ns1:6f1559a6-e0af-41bf-b14e-ff2597a3d8dc;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -690,7 +735,10 @@ teamingAI:LaneMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:003fb962-c26b-468d-9baa-7a03d84c9322 ]
+        rr:objectMap [
+            rr:constant ns1:003fb962-c26b-468d-9baa-7a03d84c9322;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -726,7 +774,10 @@ teamingAI:LaneSetMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:73c4071b-a618-49df-8119-573a1e21e652 ]
+        rr:objectMap [
+            rr:constant ns1:73c4071b-a618-49df-8119-573a1e21e652;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -770,7 +821,10 @@ teamingAI:ManualTaskMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:969d520f-2946-4323-940a-b4e21891d428 ]
+        rr:objectMap [
+            rr:constant ns1:969d520f-2946-4323-940a-b4e21891d428;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -810,7 +864,10 @@ teamingAI:MessageEventDefinitionMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:d45c81c4-ab87-4dc1-b324-1c3289e2c36a ]
+        rr:objectMap [
+            rr:constant ns1:d45c81c4-ab87-4dc1-b324-1c3289e2c36a;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -838,7 +895,10 @@ teamingAI:MessageFlowMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:28b6c81b-e493-4dc4-b700-d062cc08e86a ]
+        rr:objectMap [
+            rr:constant ns1:28b6c81b-e493-4dc4-b700-d062cc08e86a;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -890,7 +950,10 @@ teamingAI:ParallelGatewayMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:5099bb41-9d87-475c-80d0-5767ba32b0bb ]
+        rr:objectMap [
+            rr:constant ns1:5099bb41-9d87-475c-80d0-5767ba32b0bb;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:has_defaultElement;
@@ -934,7 +997,10 @@ teamingAI:ParticipantMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:9a54f457-bfc3-46ba-93db-560eaaa183d3 ]
+        rr:objectMap [
+            rr:constant ns1:9a54f457-bfc3-46ba-93db-560eaaa183d3;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -982,7 +1048,10 @@ teamingAI:ProcessMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:0996925f-9d2c-497c-86df-fad62d974790 ]
+        rr:objectMap [
+            rr:constant ns1:0996925f-9d2c-497c-86df-fad62d974790;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate prov:wasDerivedFrom;
@@ -1010,7 +1079,10 @@ teamingAI:PropertyMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:e7bc4c02-f476-430a-b3a0-2fa62e9245eb ]
+        rr:objectMap [
+            rr:constant ns1:e7bc4c02-f476-430a-b3a0-2fa62e9245eb;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -1062,7 +1134,10 @@ teamingAI:ReceiveTaskMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:3c8764ac-576d-4b4f-ae58-c42d30265240 ]
+        rr:objectMap [
+            rr:constant ns1:3c8764ac-576d-4b4f-ae58-c42d30265240;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -1110,7 +1185,10 @@ teamingAI:ScriptTaskMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:2691ce7b-82ae-4a66-ba8a-d84d5103a69a ]
+        rr:objectMap [
+            rr:constant ns1:2691ce7b-82ae-4a66-ba8a-d84d5103a69a;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -1158,7 +1236,10 @@ teamingAI:SendTaskMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:6c3de872-2ddf-465a-941b-3b7080d09866 ]
+        rr:objectMap [
+            rr:constant ns1:6c3de872-2ddf-465a-941b-3b7080d09866;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -1194,7 +1275,10 @@ teamingAI:SequenceFlowMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:e146c432-9a2f-41aa-b9a1-5efb8a8174e4 ]
+        rr:objectMap [
+            rr:constant ns1:e146c432-9a2f-41aa-b9a1-5efb8a8174e4;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:has_sourceRef;
@@ -1250,7 +1334,10 @@ teamingAI:ServiceTaskMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:ca45e504-9421-4916-9f73-6500b9f45095 ]
+        rr:objectMap [
+            rr:constant ns1:ca45e504-9421-4916-9f73-6500b9f45095;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -1298,7 +1385,10 @@ teamingAI:StartEventMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:298c0ed5-2624-4865-9c87-439d89640746 ]
+        rr:objectMap [
+            rr:constant ns1:298c0ed5-2624-4865-9c87-439d89640746;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:has_outgoing;
@@ -1350,7 +1440,10 @@ teamingAI:SubProcessMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:270b79df-7a22-4064-a8a0-f5713873700d ]
+        rr:objectMap [
+            rr:constant ns1:270b79df-7a22-4064-a8a0-f5713873700d;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToRAMILayer;
@@ -1398,7 +1491,10 @@ teamingAI:TaskMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:3a7c56c8-30b5-4b31-a1c9-f6d7ae0929b7 ]
+        rr:objectMap [
+            rr:constant ns1:3a7c56c8-30b5-4b31-a1c9-f6d7ae0929b7;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;
@@ -1430,7 +1526,10 @@ teamingAI:TextAnnotationMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:05dfacae-2772-458f-a54e-b996b0499501 ]
+        rr:objectMap [
+            rr:constant ns1:05dfacae-2772-458f-a54e-b996b0499501;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -1478,7 +1577,10 @@ teamingAI:UserTaskMapping
     ],
     [
         rr:predicate org:classification;
-        rr:objectMap [ rr:constant ns1:8b23ea64-8748-46e6-90ce-dd85cfdafe8d ]
+        rr:objectMap [
+            rr:constant ns1:8b23ea64-8748-46e6-90ce-dd85cfdafe8d;
+            rr:termType rr:IRI
+        ]
     ],
     [
         rr:predicate bbo:name;

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -1,6 +1,7 @@
 export const mapping = (virtualFileUri) => `
 @prefix bbo: <https://www.irit.fr/recherches/MELODI/ontologies/BBO#>.
 @prefix bboExtension: <https://www.teamingai-project.eg/BBOExtension#>.
+@prefix dct: <http://purl.org/dc/terms/>.
 @prefix ql: <http://semweb.mmlab.be/ns/ql#>.
 @prefix rami: <https://w3id.org/i40/rami#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
@@ -13,7 +14,6 @@ export const mapping = (virtualFileUri) => `
 @prefix muCore: <http://mu.semte.ch/vocabularies/core/>.
 @prefix prov: <http://www.w3.org/ns/prov#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix org: <http://www.w3.org/ns/org#>.
 @prefix ns1: <http://lblod.data.gift/concepts/>.
 
 <#UuidFunctionMapping>
@@ -45,7 +45,7 @@ teamingAI:AssociationMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:00cbc3c9-b2a8-4474-bbe9-c3a977f3feaf;
             rr:termType rr:IRI
@@ -100,7 +100,7 @@ teamingAI:BoundaryEventMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:9a72a481-d111-405b-903b-18242e121502;
             rr:termType rr:IRI
@@ -167,7 +167,7 @@ teamingAI:BusinessRuleTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:546044f1-455c-4949-8d45-df024bc76b49;
             rr:termType rr:IRI
@@ -202,7 +202,7 @@ teamingAI:CollaborationMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:ff8338d3-c491-413c-aae3-2a57dc3f75f5;
             rr:termType rr:IRI
@@ -233,7 +233,7 @@ teamingAI:DataInputAssociationMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:7a53a259-0e26-4688-8137-be50458264ec;
             rr:termType rr:IRI
@@ -276,7 +276,7 @@ teamingAI:DataObjectMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:3e0a146b-b483-40e7-a901-3144d5be2ee2;
             rr:termType rr:IRI
@@ -307,7 +307,7 @@ teamingAI:DataObjectReferenceMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:ad8ee890-12a8-4a8a-bb23-10b3b2403df0;
             rr:termType rr:IRI
@@ -346,7 +346,7 @@ teamingAI:DataOutputAssociationMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:63da1337-6cd7-441c-a5c1-940f2fbd0f34;
             rr:termType rr:IRI
@@ -385,7 +385,7 @@ teamingAI:DataStoreReferenceMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:b5de5008-7aeb-41c5-a2f2-26f1d4ca6d49;
             rr:termType rr:IRI
@@ -436,7 +436,7 @@ teamingAI:EndEventMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:55e98451-1f29-420c-87e3-3e01a7d5abc5;
             rr:termType rr:IRI
@@ -483,7 +483,7 @@ teamingAI:ErrorEventDefinitionMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:107c7feb-64ff-409f-a5ce-1e85324274fc;
             rr:termType rr:IRI
@@ -518,7 +518,7 @@ teamingAI:ErrorMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:cc636682-385a-4e63-8043-740d34e06254;
             rr:termType rr:IRI
@@ -565,7 +565,7 @@ teamingAI:ExclusiveGatewayMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:0bf0aea4-798d-4d7a-bd44-34f09f763eb3;
             rr:termType rr:IRI
@@ -624,7 +624,7 @@ teamingAI:InclusiveGatewayMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:76d6c227-ca62-4b47-8829-ebf1b60c3671;
             rr:termType rr:IRI
@@ -687,7 +687,7 @@ teamingAI:IntermediateThrowEventMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:6f1559a6-e0af-41bf-b14e-ff2597a3d8dc;
             rr:termType rr:IRI
@@ -734,7 +734,7 @@ teamingAI:LaneMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:003fb962-c26b-468d-9baa-7a03d84c9322;
             rr:termType rr:IRI
@@ -773,7 +773,7 @@ teamingAI:LaneSetMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:73c4071b-a618-49df-8119-573a1e21e652;
             rr:termType rr:IRI
@@ -820,7 +820,7 @@ teamingAI:ManualTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:969d520f-2946-4323-940a-b4e21891d428;
             rr:termType rr:IRI
@@ -863,7 +863,7 @@ teamingAI:MessageEventDefinitionMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:d45c81c4-ab87-4dc1-b324-1c3289e2c36a;
             rr:termType rr:IRI
@@ -894,7 +894,7 @@ teamingAI:MessageFlowMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:28b6c81b-e493-4dc4-b700-d062cc08e86a;
             rr:termType rr:IRI
@@ -949,7 +949,7 @@ teamingAI:ParallelGatewayMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:5099bb41-9d87-475c-80d0-5767ba32b0bb;
             rr:termType rr:IRI
@@ -996,7 +996,7 @@ teamingAI:ParticipantMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:9a54f457-bfc3-46ba-93db-560eaaa183d3;
             rr:termType rr:IRI
@@ -1047,7 +1047,7 @@ teamingAI:ProcessMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:0996925f-9d2c-497c-86df-fad62d974790;
             rr:termType rr:IRI
@@ -1078,7 +1078,7 @@ teamingAI:PropertyMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:e7bc4c02-f476-430a-b3a0-2fa62e9245eb;
             rr:termType rr:IRI
@@ -1133,7 +1133,7 @@ teamingAI:ReceiveTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:3c8764ac-576d-4b4f-ae58-c42d30265240;
             rr:termType rr:IRI
@@ -1184,7 +1184,7 @@ teamingAI:ScriptTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:2691ce7b-82ae-4a66-ba8a-d84d5103a69a;
             rr:termType rr:IRI
@@ -1235,7 +1235,7 @@ teamingAI:SendTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:6c3de872-2ddf-465a-941b-3b7080d09866;
             rr:termType rr:IRI
@@ -1274,7 +1274,7 @@ teamingAI:SequenceFlowMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:e146c432-9a2f-41aa-b9a1-5efb8a8174e4;
             rr:termType rr:IRI
@@ -1333,7 +1333,7 @@ teamingAI:ServiceTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:ca45e504-9421-4916-9f73-6500b9f45095;
             rr:termType rr:IRI
@@ -1384,7 +1384,7 @@ teamingAI:StartEventMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:298c0ed5-2624-4865-9c87-439d89640746;
             rr:termType rr:IRI
@@ -1439,7 +1439,7 @@ teamingAI:SubProcessMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:270b79df-7a22-4064-a8a0-f5713873700d;
             rr:termType rr:IRI
@@ -1490,7 +1490,7 @@ teamingAI:TaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:3a7c56c8-30b5-4b31-a1c9-f6d7ae0929b7;
             rr:termType rr:IRI
@@ -1525,7 +1525,7 @@ teamingAI:TextAnnotationMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:05dfacae-2772-458f-a54e-b996b0499501;
             rr:termType rr:IRI
@@ -1576,7 +1576,7 @@ teamingAI:UserTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
-        rr:predicate org:classification;
+        rr:predicate dct:type;
         rr:objectMap [
             rr:constant ns1:8b23ea64-8748-46e6-90ce-dd85cfdafe8d;
             rr:termType rr:IRI

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -13,6 +13,8 @@ export const mapping = (virtualFileUri) => `
 @prefix muCore: <http://mu.semte.ch/vocabularies/core/>.
 @prefix prov: <http://www.w3.org/ns/prov#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix org: <http://www.w3.org/ns/org#>.
+@prefix ns1: <http://lblod.data.gift/concepts/>.
 
 <#UuidFunctionMapping>
     fnml:functionValue [
@@ -41,6 +43,10 @@ teamingAI:AssociationMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:00cbc3c9-b2a8-4474-bbe9-c3a977f3feaf ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -89,6 +95,10 @@ teamingAI:BoundaryEventMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:9a72a481-d111-405b-903b-18242e121502 ]
     ],
     [
         rr:predicate bbo:attachedToRef;
@@ -151,6 +161,10 @@ teamingAI:BusinessRuleTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:546044f1-455c-4949-8d45-df024bc76b49 ]
+    ],
+    [
         rr:predicate bbo:name;
         rr:objectMap [ rml:reference "@name" ]
     ],
@@ -179,6 +193,10 @@ teamingAI:CollaborationMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:ff8338d3-c491-413c-aae3-2a57dc3f75f5 ]
+    ],
+    [
         rr:predicate teamingAI:belongsToProcess;
         rr:objectMap [ rr:parentTriplesMap teamingAI:ProcessMapping ]
     ].
@@ -201,6 +219,10 @@ teamingAI:DataInputAssociationMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:7a53a259-0e26-4688-8137-be50458264ec ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -239,6 +261,10 @@ teamingAI:DataObjectMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:3e0a146b-b483-40e7-a901-3144d5be2ee2 ]
+    ],
+    [
         rr:predicate teamingAI:belongsToProcess;
         rr:objectMap [ rr:parentTriplesMap teamingAI:ProcessMapping ]
     ].
@@ -261,6 +287,10 @@ teamingAI:DataObjectReferenceMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:ad8ee890-12a8-4a8a-bb23-10b3b2403df0 ]
     ],
     [
         rr:predicate bbo:name;
@@ -295,6 +325,10 @@ teamingAI:DataOutputAssociationMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:63da1337-6cd7-441c-a5c1-940f2fbd0f34 ]
+    ],
+    [
         rr:predicate teamingAI:belongsToProcess;
         rr:objectMap [ rr:parentTriplesMap teamingAI:ProcessMapping ]
     ],
@@ -325,6 +359,10 @@ teamingAI:DataStoreReferenceMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:b5de5008-7aeb-41c5-a2f2-26f1d4ca6d49 ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -371,6 +409,10 @@ teamingAI:EndEventMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:55e98451-1f29-420c-87e3-3e01a7d5abc5 ]
+    ],
+    [
         rr:predicate teamingAI:belongsToProcess;
         rr:objectMap [ rr:parentTriplesMap teamingAI:ProcessMapping ]
     ],
@@ -411,6 +453,10 @@ teamingAI:ErrorEventDefinitionMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:107c7feb-64ff-409f-a5ce-1e85324274fc ]
+    ],
+    [
         rr:predicate teamingAI:belongsToProcess;
         rr:objectMap [ rr:parentTriplesMap teamingAI:ProcessMapping ]
     ].
@@ -437,6 +483,10 @@ teamingAI:ErrorMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:cc636682-385a-4e63-8043-740d34e06254 ]
     ],
     [
         rr:predicate bbo:name;
@@ -477,6 +527,10 @@ teamingAI:ExlusiveGatewayMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:0bf0aea4-798d-4d7a-bd44-34f09f763eb3 ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -529,6 +583,10 @@ teamingAI:InclusiveGatewayMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:76d6c227-ca62-4b47-8829-ebf1b60c3671 ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -587,6 +645,10 @@ teamingAI:IntermediateThrowEventMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:6f1559a6-e0af-41bf-b14e-ff2597a3d8dc ]
+    ],
+    [
         rr:predicate teamingAI:belongsToProcess;
         rr:objectMap [ rr:parentTriplesMap teamingAI:ProcessMapping ]
     ],
@@ -627,6 +689,10 @@ teamingAI:LaneMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:003fb962-c26b-468d-9baa-7a03d84c9322 ]
+    ],
+    [
         rr:predicate teamingAI:belongsToProcess;
         rr:objectMap [ rr:parentTriplesMap teamingAI:ProcessMapping ]
     ],
@@ -657,6 +723,10 @@ teamingAI:LaneSetMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:73c4071b-a618-49df-8119-573a1e21e652 ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -699,6 +769,10 @@ teamingAI:ManualTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:969d520f-2946-4323-940a-b4e21891d428 ]
+    ],
+    [
         rr:predicate bbo:name;
         rr:objectMap [ rml:reference "@name" ]
     ],
@@ -735,6 +809,10 @@ teamingAI:MessageEventDefinitionMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:d45c81c4-ab87-4dc1-b324-1c3289e2c36a ]
+    ],
+    [
         rr:predicate teamingAI:belongsToProcess;
         rr:objectMap [ rr:parentTriplesMap teamingAI:ProcessMapping ]
     ].
@@ -757,6 +835,10 @@ teamingAI:MessageFlowMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:28b6c81b-e493-4dc4-b700-d062cc08e86a ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -807,6 +889,10 @@ teamingAI:ParallelGatewayMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:5099bb41-9d87-475c-80d0-5767ba32b0bb ]
+    ],
+    [
         rr:predicate bbo:has_defaultElement;
         rr:objectMap [ rr:template "{@default}" ]
     ],
@@ -845,6 +931,10 @@ teamingAI:ParticipantMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:9a54f457-bfc3-46ba-93db-560eaaa183d3 ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -891,6 +981,10 @@ teamingAI:ProcessMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:0996925f-9d2c-497c-86df-fad62d974790 ]
+    ],
+    [
         rr:predicate prov:wasDerivedFrom;
         rr:objectMap [ rr:template "${virtualFileUri}" ]
     ].
@@ -913,6 +1007,10 @@ teamingAI:PropertyMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:e7bc4c02-f476-430a-b3a0-2fa62e9245eb ]
     ],
     [
         rr:predicate bbo:name;
@@ -963,6 +1061,10 @@ teamingAI:ReceiveTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:3c8764ac-576d-4b4f-ae58-c42d30265240 ]
+    ],
+    [
         rr:predicate bbo:name;
         rr:objectMap [ rml:reference "@name" ]
     ],
@@ -1005,6 +1107,10 @@ teamingAI:ScriptTaskMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:2691ce7b-82ae-4a66-ba8a-d84d5103a69a ]
     ],
     [
         rr:predicate bbo:name;
@@ -1051,6 +1157,10 @@ teamingAI:SendTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:6c3de872-2ddf-465a-941b-3b7080d09866 ]
+    ],
+    [
         rr:predicate bbo:name;
         rr:objectMap [ rml:reference "@name" ]
     ],
@@ -1081,6 +1191,10 @@ teamingAI:SequenceFlowMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:e146c432-9a2f-41aa-b9a1-5efb8a8174e4 ]
     ],
     [
         rr:predicate bbo:has_sourceRef;
@@ -1135,6 +1249,10 @@ teamingAI:ServiceTaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:ca45e504-9421-4916-9f73-6500b9f45095 ]
+    ],
+    [
         rr:predicate bbo:name;
         rr:objectMap [ rml:reference "@name" ]
     ],
@@ -1177,6 +1295,10 @@ teamingAI:StartEventMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:298c0ed5-2624-4865-9c87-439d89640746 ]
     ],
     [
         rr:predicate bbo:has_outgoing;
@@ -1227,6 +1349,10 @@ teamingAI:SubProcessMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:270b79df-7a22-4064-a8a0-f5713873700d ]
+    ],
+    [
         rr:predicate teamingAI:belongsToRAMILayer;
         rr:objectMap [ rr:constant rami:Business ]
     ],
@@ -1271,6 +1397,10 @@ teamingAI:TaskMapping
         rr:objectMap <#UuidFunctionMapping>
     ],
     [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:3a7c56c8-30b5-4b31-a1c9-f6d7ae0929b7 ]
+    ],
+    [
         rr:predicate bbo:name;
         rr:objectMap [ rml:reference "@name" ]
     ],
@@ -1297,6 +1427,10 @@ teamingAI:TextAnnotationMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:05dfacae-2772-458f-a54e-b996b0499501 ]
     ],
     [
         rr:predicate teamingAI:belongsToProcess;
@@ -1341,6 +1475,10 @@ teamingAI:UserTaskMapping
     [
         rr:predicate muCore:uuid;
         rr:objectMap <#UuidFunctionMapping>
+    ],
+    [
+        rr:predicate org:classification;
+        rr:objectMap [ rr:constant ns1:8b23ea64-8748-46e6-90ce-dd85cfdafe8d ]
     ],
     [
         rr:predicate bbo:name;

--- a/bbo-mapping.js
+++ b/bbo-mapping.js
@@ -533,7 +533,7 @@ teamingAI:ErrorMapping
         rr:objectMap [ rr:parentTriplesMap teamingAI:ProcessMapping ]
     ].
 
-teamingAI:ExlusiveGatewayMapping
+teamingAI:ExclusiveGatewayMapping
     a rr:TriplesMap;
 
     rml:logicalSource [


### PR DESCRIPTION
After consulting Boris: we're now using `dct:type` instead of `org:classification`