### PR TITLE
Remove endpoint for BPMN file conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,3 @@ LABEL maintainer="info@redpencil.io"
 ENV SUDO_QUERY_RETRY="true"
 ENV SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES="404,500,503"
 ENV WRITE_DEBUG_TTLS="true"
-
-# Source: https://pptr.dev/troubleshooting#running-puppeteer-in-docker
-RUN apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
-
-# Source: https://stackoverflow.com/questions/71387999/node-js-puppeteer-failing-in-docker-error-while-loading-shared-libraries-lib
-RUN apt-get update \
-    && apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 \
-      libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 \
-      libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 \
-      libxss1 libxtst6 ca-certificates fonts-liberation libnss3 lsb-release xdg-utils wget

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ The OPH BPMN service is effectively a REST API. It is implemented using the [Exp
 
 The file targeted by the provided file ID is passed to an RML mapper, which expects a BPMN file and iterates over its BPMN elements. The rules specified in [bbo-mapping.js] outline which elements should be converted to triples and eventually inserted into the triplestore.
 
+The endpoint does not wait for the process steps' extraction and insertion into the triplestore. Instead, it fires up a background job responsible for this, and immediately returns an `HTTP 202` response. A subject of type `http://vocab.deri.ie/cogs#Job` is added to the `http://mu.semte.ch/graphs/bpmn-job` graph in the connected triple store. Among others, it holds a property referring to the URI of the BPMN file at stake (i.e. `http://mu.semte.ch/vocabularies/ext/relatedTo`), as well as a property indicating the job's status (i.e. `http://www.w3.org/ns/adms#status`). The latter can assume one of the following values:
+
+- `http://redpencil.data.gift/id/concept/JobStatus/scheduled`
+- `http://redpencil.data.gift/id/concept/JobStatus/busy`
+- `http://redpencil.data.gift/id/concept/JobStatus/success`
+- `http://redpencil.data.gift/id/concept/JobStatus/failed`
+- `http://redpencil.data.gift/id/concept/JobStatus/canceled`
+
+> The [Open Proces Huis microservices stack](https://github.com/lblod/app-openproceshuis) is configured in such a way that it allows for API requests for these _job_ resources. E.g. the `GET` request `/jobs?filter[:exact:resource]=http://mu.semte.ch/services/file-service/files/123` returns all data regarding the job that was fired after the file with file ID _123_ was targeted for process steps extraction and insertion.
+
 #### Query parameters
 
 - `id`: the ID of the file whose process steps should be extracted and inserted into the triplestore.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # BPMN service Open Proces Huis
 
-One of the Open Proces Huis' main functionalities lies in the processing of BPMN files. On the one hand, the process steps that make up a BPMN file process should be converted to triples and subsequently inserted into a given triplestore, and on the other, BPMN files should be available for download in different formats, which requires a conversion step. Both functionalities are handled by the OPH BPMN service, whose implementation can be found in this repo.
+One of the Open Proces Huis' main functionalities lies in the processing of BPMN files. Specifically, the process steps that make up a BPMN file process should be converted to triples and subsequently inserted into a given triplestore. This functionality is handled by the OPH BPMN service, whose implementation can be found in this repo.
 
 The OPH BPMN service is part of the [Open Proces Huis microservices stack](https://github.com/lblod/app-openproceshuis).
 
 ## Endpoints
 
-The OPH BPMN service is effectively a REST API. It is implemented using the [Express](https://expressjs.com/) framework and exposes two endpoints.
-
-> The paths for the endpoints don't seem to make much sense considering the BPMN service on its own. However, the service is specifically designed to be part of the [OPH microservices stack](https://github.com/lblod/app-openproceshuis), which incorporates these endpoints into a longer list of available endpoints.
+The OPH BPMN service is effectively a REST API. It is implemented using the [Express](https://expressjs.com/) framework and exposes one endpoint.
 
 ### POST `/`
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,3 @@ The file targeted by the provided file ID is passed to an RML mapper, which expe
 #### Headers
 
 - `mu-session-id`: each authenticated user has its own session. Based on the user's session ID, the endpoint will find the group (_Bestuur_) and link it to the BPMN file as follows: `<file uri> schema:publisher <group uri>`. Make sure the stack containing the OPH BPMN service also contains the [mu-identifier](https://github.com/mu-semtech/mu-identifier) service, as it will automatically add this header to each authenticated request.
-
-### GET `/:id/download`
-
-The file targeted by the provided file ID is converted to the given file format and as such returned to the user, ready for downdoad.
-
-#### Route parameters
-
-- `id`: the ID of the file to be converted and subsequently downloaded.
-
-#### Headers
-
-- `accept`: the MIME type indicating the format of the file to download. The options are `image/svg+xml`, `image/png` and `application/pdf`.
-
-> Downloading a BPMN file in its original format, is not handled by the BPMN service. When using the [OPH microservices stack](https://github.com/lblod/app-openproceshuis), however, the dispatcher is configured in such a way that download requests where none of the above MIME types is provided, are dispatched to the file storage service directly.

--- a/app.js
+++ b/app.js
@@ -11,8 +11,6 @@ import {
   generateGroupUriSelectQuery,
   generateFileGroupLinkInsertQuery,
 } from "./sparql-queries.js";
-import { convert as convertBpmn } from "bpmn-to-image";
-import path from "path";
 import { runAsyncJob } from "./job.js";
 
 const STORAGE_FOLDER_PATH = "/share/";
@@ -73,48 +71,6 @@ app.post("/", async (req, res) => {
   return res
     .status(202)
     .send({ message: "process steps extraction job running" });
-});
-
-app.get("/:id/download", async (req, res) => {
-  const acceptType = req.headers["accept"];
-  let tempFilePath = path.join("/tmp", uuid());
-  if (acceptType?.includes("image/svg+xml")) {
-    tempFilePath += ".svg";
-  } else if (acceptType?.includes("image/png")) {
-    tempFilePath += ".png";
-  } else if (acceptType?.includes("application/pdf")) {
-    tempFilePath += ".pdf";
-  } else {
-    return res.status(406).send("The requested file format is not available.");
-  }
-
-  const virtualFileUuid = req.params.id;
-  const fileUriQuery = generateFileUriSelectQuery(virtualFileUuid);
-  const fileUriResult = await query(fileUriQuery);
-  const fileUriBindings = fileUriResult.results.bindings;
-  if (fileUriBindings.length === 0) {
-    return res.status(404).send("Not Found");
-  }
-  const physicalFileUri = fileUriBindings[0].physicalFileUri.value;
-
-  const bpmnFilePath = physicalFileUri.replace("share://", STORAGE_FOLDER_PATH);
-  if (!existsSync(bpmnFilePath)) {
-    return res
-      .status(500)
-      .send(
-        "Could not find file in path. Check if the physical file is available on the server and if this service has the right mountpoint."
-      );
-  }
-
-  try {
-    await convertBpmn(bpmnFilePath, tempFilePath);
-    return res.sendFile(tempFilePath, {}, async () => {
-      await unlink(tempFilePath);
-    });
-  } catch (error) {
-    console.error("error:", error);
-    return res.status(500).send(`Conversion error: ${error.message}`);
-  }
 });
 
 app.use(errorHandler);

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "homepage": "https://github.com/lblod/bpmn-service#readme",
   "dependencies": {
     "@comake/rmlmapper-js": "^0.5.2",
-    "@lblod/mu-auth-sudo": "^0.6.1",
-    "bpmn-to-image": "0.5.1",
-    "mime": "^1.6.0"
+    "@lblod/mu-auth-sudo": "^0.6.1"
   }
 }


### PR DESCRIPTION
OPH-328

Corresponding PR frontend:

Since the conversion of BPMN files to SVG, PNG and PDF is now being handled in frontend, the deprecated endpoint is removed.