### PR TITLE
Correctly update job's status on process steps extraction failure

### DIFF
--- a/job.js
+++ b/job.js
@@ -150,13 +150,14 @@ export async function runAsyncJob(
   relatedResource,
   asyncFunc = async () => {}
 ) {
+  const jobUri = await createJob(
+    jobsGraph,
+    creatorUri,
+    jobOperation,
+    relatedResource
+  );
+
   try {
-    const jobUri = await createJob(
-      jobsGraph,
-      creatorUri,
-      jobOperation,
-      relatedResource
-    );
     await asyncFunc();
     await updateStatusJob(jobsGraph, jobUri, STATUS_SUCCESS);
   } catch (error) {


### PR DESCRIPTION
OPH-344

In case something goes wrong during the extraction and insertion of a BPMN file's process steps, the corresponding error's status should be correctly updated from `busy` to `failed`.