### PR TITLE
Chunk BBO triples based on subjects

### DIFF
--- a/sparql-queries.js
+++ b/sparql-queries.js
@@ -1,10 +1,10 @@
 import { sparqlEscapeString, sparqlEscapeUri } from "mu";
 
-export function generateBboTriplesInsertQuery(bboTriples) {
+export function generateTriplesInsertQuery(triples) {
   // prettier-ignore
   return `
     INSERT DATA {
-      ${bboTriples.join("\n")}
+      ${triples.join("\n")}
     }`;
 }
 


### PR DESCRIPTION
OPH-348

While substituting mu-authorization with the sparql-parser for OPH, it was discovered the chunking of BBO triples (cfr. process steps) could lead to situations where a new resource got introduced with the corresponding rdf:type statement only being present in the following chunk.

Both mu-authorization and sparql-parser are configured to take types into account. But whereas mu-authorization apparently didn’t communicate this (and probably ignored these incomplete triples), the sparql-parser actually logs error statements and disrupts the insertion process (revealing this bug).

The current chunking functionality has been refactored to make sure all statements belonging to the same resource (same subject) appear as a whole in the same chunk of triples to insert.