### PR TITLE
Allow Visio file as process diagram

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,16 @@ LABEL maintainer="info@redpencil.io"
 ENV SUDO_QUERY_RETRY="true"
 ENV SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES="404,500,503"
 ENV WRITE_DEBUG_TTLS="true"
+
+# Install pip and graphviz
+RUN apt-get update && \
+    apt-get install -y python3-pip python3-venv graphviz && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create virtual environment and install Python packages
+RUN python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip && \
+    /venv/bin/pip install vsdx bpmn-tools
+
+# Add virtual environment to PATH
+ENV PATH="/venv/bin:$PATH"

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-import { app, update, query, errorHandler } from "mu";
+import { app, update, query, errorHandler, uuid } from "mu";
 import { querySudo } from "@lblod/mu-auth-sudo";
 import bodyParser from "body-parser";
 import { readFile } from "fs/promises";

--- a/convert_vsdx_to_bpmn.py
+++ b/convert_vsdx_to_bpmn.py
@@ -88,6 +88,5 @@ definitions.append(diagram)
 graphviz.layout(definitions)
 bpmn = util.model2xml(definitions)
 
-root_file_path, _ = os.path.splitext(visio_file_path)
-bpmn_file_path = f"{root_file_path}.bpmn"
+bpmn_file_path = sys.argv[2]
 Path(bpmn_file_path).write_text(bpmn)

--- a/convert_vsdx_to_bpmn.py
+++ b/convert_vsdx_to_bpmn.py
@@ -12,7 +12,6 @@ import sys
 # INPUT
 
 visio_file_path = sys.argv[1]
-print('visio file path:', visio_file_path)
 visio = VisioFile(visio_file_path)
 page = visio.get_page(0) # TODO: loop over pages
 
@@ -90,7 +89,5 @@ graphviz.layout(definitions)
 bpmn = util.model2xml(definitions)
 
 root_file_path, _ = os.path.splitext(visio_file_path)
-print('root file path:', root_file_path)
 bpmn_file_path = f"{root_file_path}.bpmn"
-print('bpmn file path:', bpmn_file_path)
 Path(bpmn_file_path).write_text(bpmn)

--- a/convert_vsdx_to_bpmn.py
+++ b/convert_vsdx_to_bpmn.py
@@ -1,0 +1,96 @@
+from vsdx import VisioFile
+from bpmn_tools.flow import Task, Flow, Process
+from bpmn_tools.notation import Definitions
+from bpmn_tools.diagrams import Plane, Diagram
+from bpmn_tools.collaboration import Collaboration, Participant
+from bpmn_tools.layout import graphviz
+from bpmn_tools import util
+from pathlib import Path
+import os
+import sys
+
+# INPUT
+
+visio_file_path = sys.argv[1]
+print('visio file path:', visio_file_path)
+visio = VisioFile(visio_file_path)
+page = visio.get_page(0) # TODO: loop over pages
+
+# TASKS
+
+tasks = {}
+
+for shape in page.child_shapes: # TODO: also consider deeper nested shapes
+
+  # 'Shape' shapes are 'help' elements in Visio --> of no use in BPMN
+  if shape.shape_type == 'Shape':
+    continue
+
+  tasks[shape.ID] = Task(shape.text.strip(), id=f"task_{shape.ID}")
+
+# FLOWS
+
+flows = {}
+
+for connector in page.connects:
+  task_id = connector.xml.attrib.get("ToSheet")
+
+  # Some connectors are 'help' elements in Visio --> of no use in BPMN
+  if task_id not in tasks:
+    continue
+
+  flow_id = connector.xml.attrib.get("FromSheet")
+  flow_type = connector.xml.attrib.get("FromCell")
+
+  if flow_id not in flows:
+    flows[flow_id] = {}
+
+  if flow_type == "BeginX":
+    flows[flow_id]["source_task_id"] = task_id
+  elif flow_type == "EndX":
+    flows[flow_id]["target_task_id"] = task_id
+    
+  # Create flow object when both source and target are known
+  if 'source_task_id' in flows[flow_id] and 'target_task_id' in flows[flow_id]:
+    source_task_id = flows[flow_id]["source_task_id"]
+    target_task_id = flows[flow_id]["target_task_id"]
+
+    source_task = tasks[source_task_id]
+    target_task = tasks[target_task_id]
+
+    flows[flow_id] = Flow(source_task, target_task, id=f"flow_{flow_id}") # TODO: set flow name
+
+# PROCESS
+
+process = Process()
+process.extend(tasks.values())
+process.extend(flows.values())
+
+# COLLABORATION
+
+participant = Participant(process=process) # TODO: fetch from Visio
+collaboration = Collaboration() # TODO: fetch from Visio
+collaboration.append(participant)
+
+# DIAGRAM
+
+plane = Plane(element=collaboration)
+diagram = Diagram(plane=plane)
+
+# DEFINITIONS
+
+definitions = Definitions()
+definitions.append(process)
+definitions.append(collaboration)
+definitions.append(diagram)
+
+# OUTPUT
+
+graphviz.layout(definitions)
+bpmn = util.model2xml(definitions)
+
+root_file_path, _ = os.path.splitext(visio_file_path)
+print('root file path:', root_file_path)
+bpmn_file_path = f"{root_file_path}.bpmn"
+print('bpmn file path:', bpmn_file_path)
+Path(bpmn_file_path).write_text(bpmn)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/lblod/bpmn-service#readme",
   "dependencies": {
     "@comake/rmlmapper-js": "^0.5.2",
-    "@lblod/mu-auth-sudo": "^0.6.1"
+    "@lblod/mu-auth-sudo": "^0.6.1",
+    "python-shell": "^5.0.0"
   }
 }

--- a/sparql-queries.js
+++ b/sparql-queries.js
@@ -55,18 +55,17 @@ export function generateFileGroupLinkInsertQuery(virtualFileUri, groupUri) {
 
 export function generateBpmnVisioFileInsertQuery(
   virtualFileUuid,
-  virtualFileUri,
   virtualFileName,
+  virtualFileUri,
+  physicalFileUuid,
+  physicalFileName,
+  physicalFileUri,
   fileSize,
   visioFileUri
 ) {
   const fileFormat = "text/xml; charset=utf-8";
   const fileExtension = "bpmn";
   const now = new Date();
-
-  const physicalFileUuid = uuid();
-  const physicalFileName = `${physicalFileUuid}.${fileExtension}`;
-  const physicalFileUri = `share://${physicalFileName}`;
 
   // prettier-ignore
   return `

--- a/sparql-queries.js
+++ b/sparql-queries.js
@@ -53,14 +53,15 @@ export function generateFileGroupLinkInsertQuery(virtualFileUri, groupUri) {
     }`;
 }
 
-export function generateVisioFileInsertQuery(
+export function generateBpmnVisioFileInsertQuery(
   virtualFileUuid,
   virtualFileUri,
   virtualFileName,
-  fileSize
+  fileSize,
+  visioFileUri
 ) {
-  const fileFormat = "application/octet-stream; charset=binary";
-  const fileExtension = "vsdx";
+  const fileFormat = "text/xml; charset=utf-8";
+  const fileExtension = "bpmn";
   const now = new Date();
 
   const physicalFileUuid = uuid();
@@ -83,7 +84,8 @@ export function generateVisioFileInsertQuery(
           nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
           dbpedia:fileExtension ${sparqlEscapeString(fileExtension)} ;
           dc:created ${sparqlEscapeDateTime(now)} ;
-          dc:modified ${sparqlEscapeDateTime(now)} .
+          dc:modified ${sparqlEscapeDateTime(now)} ;
+          prov:wasDerivedFrom ${sparqlEscapeUri(visioFileUri)} .
 
       ${sparqlEscapeUri(physicalFileUri)} a nfo:FileDataObject ;
           nie:dataSource ${sparqlEscapeUri(virtualFileUri)} ;

--- a/sparql-queries.js
+++ b/sparql-queries.js
@@ -75,6 +75,7 @@ export function generateBpmnVisioFileInsertQuery(
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dc: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
 
     INSERT DATA {
       ${sparqlEscapeUri(virtualFileUri)} a nfo:FileDataObject ;

--- a/sparql-queries.js
+++ b/sparql-queries.js
@@ -13,11 +13,13 @@ export function generateFileUriSelectQuery(virtualFileUuid) {
   return `
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+    PREFIX dbpedia: <http://dbpedia.org/ontology/>
 
-    SELECT ?virtualFileUri ?physicalFileUri
+    SELECT ?virtualFileUri ?physicalFileUri ?fileExtension
     WHERE {
       ?virtualFileUri mu:uuid ${sparqlEscapeString(virtualFileUuid)} .
       ?physicalFileUri nie:dataSource ?virtualFileUri .
+      ?physicalFileUri dbpedia:fileExtension ?fileExtension .
     }`;
 }
 


### PR DESCRIPTION
OPH-396

Corresponding PRs:
- app: https://github.com/lblod/app-openproceshuis/pull/38
- frontend: https://github.com/lblod/frontend-openproceshuis/pull/57

If the call to extract bpmn elements points to a Visio (.vsdx) file, first generate a BPMN file from it. The BPMN file generation happens through a Python script, in order to be able to use the pip vsdx package.