### PR TITLE
feat: bump javascript image to be 1.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-javascript-template:1.8.0
+FROM semtech/mu-javascript-template:1.9.1
 LABEL maintainer="info@redpencil.io"
 ENV SUDO_QUERY_RETRY="true"
 ENV SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES="404,500,503"


### PR DESCRIPTION
## Description

Bump the dockerfile image and run it allong side your dev setup to start with. When all is ok and the original functionality is still working we can publish this version bump.

## How to test

Run the service everything should work the same as before (even better normally)

> [!Warning]
Didn't find anything that breaks the current flow. I did find a bug with the  turtle parsing! Will create a bug for it.

## Links to other PR's

- https://github.com/lblod/app-openproceshuis/pull/93
- https://github.com/lblod/openproceshuis-process-service/pull/7